### PR TITLE
Fix Selection.getRangeAt(0) index size error

### DIFF
--- a/jquery.textselectevent.js
+++ b/jquery.textselectevent.js
@@ -38,7 +38,7 @@
 		getOrigin = function (input) {
 			return docSel && docSel.createRange().parentElement()
 				|| input
-				|| winSel && winSel.getRangeAt(0).commonAncestorContainer
+				|| winSel && winSel.rangeCount && winSel.getRangeAt(0).commonAncestorContainer
 				|| document.body;
 		},
 


### PR DESCRIPTION
According to docs, index given to Selection.getRangeAt() cannot be >= Selection.rangeCount.
